### PR TITLE
Rebuild for python 3.14

### DIFF
--- a/.ci_support/migrations/python314.yaml
+++ b/.ci_support/migrations/python314.yaml
@@ -1,0 +1,41 @@
+# this is intentionally sorted before the 3.13t migrator, because that determines
+# the order of application of the migrators; otherwise we'd have to add values for
+# is_freethreading and is_abi3 keys here, since that migration extends the zip;
+migrator_ts: 1724712607
+__migrator:
+    commit_message: Rebuild for python 3.14
+    migration_number: 1
+    operation: key_add
+    primary_key: python
+    ordering:
+        python:
+            - 3.9.* *_cpython
+            - 3.10.* *_cpython
+            - 3.11.* *_cpython
+            - 3.12.* *_cpython
+            - 3.13.* *_cp313
+            - 3.13.* *_cp313t
+            - 3.14.* *_cp314  # new entry
+    paused: false
+    longterm: true
+    pr_limit: 5
+    max_solver_attempts: 3  # this will make the bot retry "not solvable" stuff 12 times
+    exclude:
+        # this shouldn't attempt to modify the python feedstocks
+        - python
+        - pypy3.6
+        - pypy-meta
+        - cross-python
+        - python_abi
+        # Manually migrated (e.g. were blocked on missing dev dependencies)
+        - pyarrow
+    exclude_pinned_pkgs: false
+    ignored_deps_per_node:
+        matplotlib:
+            - pyqt
+
+python:
+- 3.14.* *_cp314
+# additional entries to add for zip_keys
+is_python_min:
+- false

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   script: {{ PYTHON }} -m pip install . --no-build-isolation -vv
-  number: 0
+  number: 1
   skip: true  # [py<3.10]
 
 requirements:


### PR DESCRIPTION
Opt in to conda-forge's `python314` migration so anuga ships CPython 3.14 packages.

### Why now

The migration PR (#8) was closed back in March because the build genuinely failed:

```
meson-python: error: The package requires Python version <3.14,>3.8, running on 3.14.0rc3
```

That cap is gone. anuga upstream now declares `requires-python = ">=3.10, <3.15"` with a
`Programming Language :: Python :: 3.14` classifier, and 3.3.8 already ships `cp314` wheels on
PyPI for linux, macOS (x86_64 + arm64) and Windows. All runtime dependencies have py314 builds
(`meshpy`, `pymetis`, `netcdf4`, `scipy`, `numpy`, `matplotlib-base`), and the rest
(`xarray`, `dill`, `utm`, `meson-python`, `pybind11`) are `noarch`.

Because the bot only opens one PR per migration and #8 was closed, it never re-offered it — so
this opts in manually.

### Changes

- add `.ci_support/migrations/python314.yaml` (copied verbatim from conda-forge-pinning)
- bump build number for the rebuild

Rerender to follow via `@conda-forge-admin, please rerender`.

### Checklist

- [ ] Tests pass on all platforms for py3.10–3.14
